### PR TITLE
YC Update matlab version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ BRAPH 2.0 is designed to facilitate the analysis of brain connectivity using var
 
 To install BRAPH 2.0, follow these steps:
 
-1. Ensure that you have **MATLAB R2021a or a later version** installed on your system. BRAPH 2.0 is compatible with the versions of MATLAB for Microsoft Windows, macOS, and Linux operating systems.
+1. Ensure that you have **MATLAB R2022a or a later version** installed on your system. BRAPH 2.0 is compatible with the versions of MATLAB for Microsoft Windows, macOS, and Linux operating systems.
 
 2. Make sure you have the following toolboxes installed in MATLAB:
     * **Statistics and Machine Learning Toolbox** (required)

--- a/braph2/src/util/BRAPH2.m
+++ b/braph2/src/util/BRAPH2.m
@@ -11,7 +11,7 @@ classdef BRAPH2
     %  COPYRIGHT        - BRAPH2 copyright
     %  WEB              - BRAPH2 website
     %  TWITTER          - BRAPH2 twitter handle
-    %  MATLAB_RELEASE   - Minimal MatLab version (2020b)
+    %  MATLAB_RELEASE   - Minimal MatLab version (2022a)
     %
     % Properties (Constant) - BRAPH2 extensions
     %  EXT_ELEMENT      - BRAPH2 element extension (*.b2)
@@ -71,7 +71,7 @@ classdef BRAPH2
         COPYRIGHT = ['Copyright 2014-' datestr(now,'yyyy')]
         WEB = 'braph.org' % BRAPH2 website
         TWITTER = 'braph2software' % BRAPH2 twitter handle
-        MATLAB_RELEASE = '9.10'; % Minimal MatLab release (2021a)
+        MATLAB_RELEASE = '9.12'; % Minimal MatLab release (2022a)
     end
     properties (Constant) % BRAPH2 extensions
         EXT_ELEMENT = {'*.b2'} % BRAPH2 element extension

--- a/braph2genesis/src/util/BRAPH2.m
+++ b/braph2genesis/src/util/BRAPH2.m
@@ -11,7 +11,7 @@ classdef BRAPH2
     %  COPYRIGHT        - BRAPH2 copyright
     %  WEB              - BRAPH2 website
     %  TWITTER          - BRAPH2 twitter handle
-    %  MATLAB_RELEASE   - Minimal MatLab version (2020b)
+    %  MATLAB_RELEASE   - Minimal MatLab version (2022a)
     %
     % Properties (Constant) - BRAPH2 extensions
     %  EXT_ELEMENT      - BRAPH2 element extension (*.b2)
@@ -71,7 +71,7 @@ classdef BRAPH2
         COPYRIGHT = ['Copyright 2014-' datestr(now,'yyyy')]
         WEB = 'braph.org' % BRAPH2 website
         TWITTER = 'braph2software' % BRAPH2 twitter handle
-        MATLAB_RELEASE = '9.10'; % Minimal MatLab release (2021a)
+        MATLAB_RELEASE = '9.12'; % Minimal MatLab release (2022a)
     end
     properties (Constant) % BRAPH2 extensions
         EXT_ELEMENT = {'*.b2'} % BRAPH2 element extension


### PR DESCRIPTION
This PR updates the least matlabe version to be R2022a due to the usage of [rocmetrics ](https://se.mathworks.com/help/stats/rocmetrics.html)function. This function is essential for multi-class classification problem (more than 2 classes).

ReadMe and BRAPH2.m have been updated accordingly.